### PR TITLE
Feat/event priority

### DIFF
--- a/src/midi_event_handler/core/events/handlers.py
+++ b/src/midi_event_handler/core/events/handlers.py
@@ -103,7 +103,7 @@ class MidiEventHandler:
         self.midiout.send_multiple(self.event.end_messages)
         self._event_started_at = None
 
-        # Should happen ONLY if an event with high priority opened the lock
+        # Should happen if an event with high priority opened the lock or None got injected
         if self._min_duration_task and not self._min_duration_task.done():
             self._min_duration_task.cancel()
         # Will happen if the full duration is not expanded
@@ -140,12 +140,14 @@ class MidiEventHandler:
         if next_event is None or self.event is None:
             return False
         if next_event == self.event:
+            log.info(f"[DISCARD] CURRENT == NEXT - {next_event}")
             return True
         if not self.locked:
             return False
         if next_event.priority > self.event.priority:
             self.locked = False
             return False
+        log.info(f"[DISCARD] Locked and low priority (NEXT:{next_event.priority} <= CURRENT:{self.event.priority})")
         return True
 
     async def _schedule_fallback_event(self):
@@ -189,7 +191,6 @@ class MidiEventHandler:
                 next_event = await self.event_queue.get()
                 _log_event_state("NEXT", next_event)
                 if self._should_discard_next_event(next_event):
-                    _log_event_state("DISCARDED", next_event)
                     continue
                 if self.event:
                     await self._end_current_event()

--- a/src/midi_event_handler/core/events/handlers.py
+++ b/src/midi_event_handler/core/events/handlers.py
@@ -14,10 +14,8 @@ import logging
 
 log = logging.getLogger(__name__)
 
-TASK_YIELD_DELAY = 0.001
 
-
-def _log_event_state(flag: str, event: MidiEvent):
+def _log_event_state(flag: str, event: MidiEvent | None):
     log.info(f"[{flag.upper()}] {event}")
 
 
@@ -105,7 +103,7 @@ class MidiEventHandler:
         self.midiout.send_multiple(self.event.end_messages)
         self._event_started_at = None
 
-        # Should NOT happen
+        # Should happen ONLY if an event with high priority opened the lock
         if self._min_duration_task and not self._min_duration_task.done():
             self._min_duration_task.cancel()
         # Will happen if the full duration is not expanded
@@ -123,10 +121,8 @@ class MidiEventHandler:
         if self.event.duration_min:
             self.locked = True
             self._min_duration_task = asyncio.create_task(self._unlock_after_min_duration())
-            await asyncio.sleep(TASK_YIELD_DELAY)
         if self.event.duration_max:
             self._fallback_scheduler_task = asyncio.create_task(self._schedule_fallback_event())
-            await asyncio.sleep(TASK_YIELD_DELAY)
         _log_event_state("STARTED", self.event)
 
         await notify_event_change(self.event.name, "start")
@@ -137,6 +133,20 @@ class MidiEventHandler:
         await asyncio.sleep(self.event.duration_min)
         self.locked = False
         log.info(f"[UNLOCK] Event unlocked after {self.event.duration_min} seconds")
+
+    def _should_discard_next_event(self, next_event: MidiEvent | None) -> bool:
+        # Idle (no current): always take the next item. None in the queue: manual stop / placeholder — never discard here.
+        # Priority and duplicate checks only apply when both sides are real events.
+        if next_event is None or self.event is None:
+            return False
+        if next_event == self.event:
+            return True
+        if not self.locked:
+            return False
+        if next_event.priority > self.event.priority:
+            self.locked = False
+            return False
+        return True
 
     async def _schedule_fallback_event(self):
         try:
@@ -176,9 +186,9 @@ class MidiEventHandler:
         self.event = None
         try:
             while True:
-                next_event: MidiEvent = await self.event_queue.get()
+                next_event = await self.event_queue.get()
                 _log_event_state("NEXT", next_event)
-                if self.locked or (next_event and next_event == self.event):
+                if self._should_discard_next_event(next_event):
                     _log_event_state("DISCARDED", next_event)
                     continue
                 if self.event:

--- a/src/midi_event_handler/core/events/models.py
+++ b/src/midi_event_handler/core/events/models.py
@@ -55,8 +55,20 @@ class MidiEvent:
     end_messages: list[MidiMessage] = field(default_factory=list)
     duration_min: int | None = None
     duration_max: int | None = None
+    #: Serialized when set (including ``0``). ``None`` = omit from YAML; compare via :attr:`priority` as ``0``.
+    _priority: int | None = None
     fallback_event: str | None = None
     comment: str | None = None
+
+    @property
+    def priority(self) -> int:
+        """Effective priority for runtime rules; ``0`` when not set in YAML."""
+        return 0 if self._priority is None else self._priority
+
+    @priority.setter
+    def priority(self, value: int | None) -> None:
+        """``None`` clears stored priority (omitted from export); integer persists (including ``0``)."""
+        self._priority = None if value is None else int(value)
 
     @classmethod
     def from_dict(cls, data: dict) -> "MidiEvent":
@@ -73,6 +85,11 @@ class MidiEvent:
         start = [MidiMessage(**m) for m in data.get("start_messages", [])]
         end = [MidiMessage(**m) for m in data.get("end_messages", [])]
 
+        stored_priority = None
+        if "priority" in data:
+            pv = data.get("priority")
+            stored_priority = int(pv) if pv is not None else None
+
         return cls(
             name=data.get("name", ""),
             type=data.get("type", ""),
@@ -81,6 +98,7 @@ class MidiEvent:
             end_messages=end,
             duration_min=data.get("duration_min"),
             duration_max=data.get("duration_max"),
+            _priority=stored_priority,
             fallback_event=data.get("fallback_event"),
             comment=data.get("comment"),
         )
@@ -104,6 +122,8 @@ class MidiEvent:
             d["duration_min"] = self.duration_min
         if self.duration_max is not None:
             d["duration_max"] = self.duration_max
+        if self._priority is not None:
+            d["priority"] = self._priority
         if self.fallback_event:
             d["fallback_event"] = self.fallback_event
         if self.comment:

--- a/src/midi_event_handler/web/routers/editor/events.py
+++ b/src/midi_event_handler/web/routers/editor/events.py
@@ -140,6 +140,16 @@ async def event_save(request: Request):
     except (json.JSONDecodeError, ValueError, TypeError) as e:
         log.warning(f"Failed to parse end_messages: {e}")
 
+    priority_raw = form.get("priority", "").strip()
+    stored_priority: int | None
+    if not priority_raw:
+        stored_priority = None
+    else:
+        try:
+            stored_priority = int(float(priority_raw))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="priority must be a number")
+
     event = MidiEvent(
         name=name,
         type=form.get("type", "").strip(),
@@ -151,6 +161,7 @@ async def event_save(request: Request):
         end_messages=end_messages,
         duration_min=int(form.get("duration_min") or 0) or None,
         duration_max=int(form.get("duration_max") or 0) or None,
+        _priority=stored_priority,
         fallback_event=form.get("fallback_event", "").strip() or None,
         comment=form.get("comment", "").strip() or None,
     )

--- a/src/midi_event_handler/web/templates/partials/editor/editor_content.html
+++ b/src/midi_event_handler/web/templates/partials/editor/editor_content.html
@@ -232,6 +232,10 @@
                             <span class="event-badge-value">{{ event.duration_min or 0 }}s → {{ event.duration_max or '∞' }}s</span>
                         </span>
                         {% endif %}
+                        <span class="event-badge event-badge-priority {% if event._priority is none %}badge-muted{% endif %}">
+                            <span class="event-badge-label">Priority</span>
+                            <span class="event-badge-value">{% if event._priority is none %}0{% else %}{{ event._priority }}{% endif %}</span>
+                        </span>
                         {% if event.fallback_event %}
                         <span class="event-badge event-badge-fallback {{ 'badge-error' if not fallback_valid else '' }}">
                             <span class="event-badge-label">Fallback</span>

--- a/src/midi_event_handler/web/templates/partials/editor/modals/event_form.html
+++ b/src/midi_event_handler/web/templates/partials/editor/modals/event_form.html
@@ -103,6 +103,24 @@
 </div>
 
 <div class="form-group">
+    <label for="event-priority">Priority <span class="optional">(optional)</span></label>
+    <div class="input-with-clear">
+        <input type="number"
+               id="event-priority"
+               name="priority"
+               value="{% if event._priority is not none %}{{ event._priority }}{% endif %}"
+               min="0"
+               step="1"
+               placeholder="0 when not set"
+               autocomplete="off">
+        <button type="button" class="btn-clear" data-action="clear-input" title="Clear">
+            <img src="/static/assets/icons/x-mark.svg" class="icon icon-sm" alt="">
+        </button>
+    </div>
+    <div class="form-hint">Higher values preempt during minimum duration lock. Clear the field so nothing is saved (effective priority 0).</div>
+</div>
+
+<div class="form-group">
     <label for="fallback-event">Fallback Event</label>
     <select id="fallback-event" name="fallback_event">
         <option value="">-- None --</option>

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,112 @@
+"""Tests for MIDI event handler queue / discard logic."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from midi_event_handler.core.events.handlers import MidiEventHandler
+from midi_event_handler.core.events.models import MidiChord, MidiEvent
+
+
+def _event(name: str, stored_priority: int | None = None) -> MidiEvent:
+    return MidiEvent(
+        name=name,
+        type="light",
+        chord=MidiChord(port="in1", notes=[60]),
+        _priority=stored_priority,
+    )
+
+
+@pytest.fixture
+def handler() -> MidiEventHandler:
+    return MidiEventHandler(
+        asyncio.Queue(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+
+class TestShouldDiscardNextEvent:
+    """Unit tests for MidiEventHandler._should_discard_next_event."""
+
+    def test_never_discard_when_next_is_none(self, handler):
+        handler.event = _event("current")
+        handler.locked = True
+        assert handler._should_discard_next_event(None) is False
+
+    def test_never_discard_when_idle(self, handler):
+        handler.event = None
+        handler.locked = False
+        assert handler._should_discard_next_event(_event("incoming")) is False
+
+    def test_discard_when_next_equals_current_snapshot(self, handler):
+        current = _event("same", stored_priority=None)
+        incoming = _event("same", stored_priority=None)
+        assert current is not incoming
+        assert current == incoming
+
+        handler.event = current
+        handler.locked = True
+        assert handler._should_discard_next_event(incoming) is True
+        assert handler.locked is True
+
+    def test_no_discard_when_unlocked_even_if_priorities_differ(self, handler):
+        handler.event = _event("current", stored_priority=None)
+        handler.locked = False
+        incoming = _event("other", stored_priority=99)
+        assert handler._should_discard_next_event(incoming) is False
+
+    def test_discard_when_locked_and_next_priority_not_strictly_greater(self, handler):
+        handler.event = _event("current", stored_priority=5)
+        handler.locked = True
+        same = _event("other", stored_priority=5)
+        lower = _event("other2", stored_priority=3)
+
+        assert handler._should_discard_next_event(same) is True
+        assert handler.locked is True
+
+        assert handler._should_discard_next_event(lower) is True
+        assert handler.locked is True
+
+    def test_preempt_when_locked_and_next_priority_strictly_greater(self, handler):
+        handler.event = _event("current", stored_priority=1)
+        handler.locked = True
+        incoming = _event("incoming", stored_priority=2)
+
+        assert handler._should_discard_next_event(incoming) is False
+        assert handler.locked is False
+
+    def test_effective_priority_zero_when_unset_on_both_under_lock(self, handler):
+        """Unset _priority behaves as 0; equal effective priority → discard while locked."""
+        handler.event = _event("current", stored_priority=None)
+        handler.locked = True
+        incoming = _event("other", stored_priority=None)
+        assert incoming.priority == handler.event.priority == 0
+
+        assert handler._should_discard_next_event(incoming) is True
+        assert handler.locked is True
+
+    def test_logs_duplicate_discard_reason(self, handler, caplog):
+        caplog.set_level("INFO")
+
+        handler.event = _event("a")
+        duplicate = _event("a")
+
+        handler.locked = True
+        handler._should_discard_next_event(duplicate)
+
+        assert any("CURRENT == NEXT" in r.message for r in caplog.records)
+
+    def test_logs_low_priority_discard_under_lock(self, handler, caplog):
+        caplog.set_level("INFO")
+
+        handler.event = _event("current", stored_priority=5)
+        handler.locked = True
+        low = _event("low", stored_priority=3)
+
+        handler._should_discard_next_event(low)
+
+        assert any("Locked and low priority" in r.message for r in caplog.records)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,6 +104,9 @@ class TestMidiEvent:
         assert event.duration_max is None
         assert event.fallback_event is None
         assert event.comment is None
+        assert event._priority is None
+        assert event.priority == 0
+        assert "priority" not in event.to_dict()
 
     def test_create_full_event(self):
         chord = MidiChord(notes=[60, 64], port="input1")
@@ -188,3 +191,42 @@ class TestMidiEvent:
         assert d["type"] == "light"
         assert d["trigger"]["notes"] == [60]
         assert d["trigger"]["port"] == "input1"
+
+    def test_to_dict_without_priority_key_when_unspecified(self):
+        chord = MidiChord(notes=[60], port="input1")
+        event = MidiEvent(name="test", type="light", chord=chord)
+        assert "priority" not in event.to_dict()
+
+    def test_to_dict_includes_explicit_priority_zero(self):
+        chord = MidiChord(notes=[60], port="input1")
+        event = MidiEvent(name="test", type="light", chord=chord, _priority=0)
+        assert event.to_dict().get("priority") == 0
+
+    def test_priority_property_and_setter(self):
+        chord = MidiChord(notes=[60], port="input1")
+        event = MidiEvent(name="test", type="light", chord=chord)
+        assert event.priority == 0
+        event.priority = None
+        assert event._priority is None
+        event.priority = 5
+        assert event._priority == 5
+        assert event.priority == 5
+
+    def test_from_dict_omitted_priority_vs_explicit(self):
+        base = {"name": "x", "type": "light", "trigger": {"port": "input1", "notes": [60]}}
+
+        e1 = MidiEvent.from_dict({**base})
+        assert e1._priority is None
+        assert e1.priority == 0
+        assert "priority" not in e1.to_dict()
+
+        e2 = MidiEvent.from_dict({**base, "priority": 3})
+        assert e2._priority == 3
+        assert e2.to_dict().get("priority") == 3
+
+        e3 = MidiEvent.from_dict({**base, "priority": 0})
+        assert e3._priority == 0
+        assert e3.to_dict().get("priority") == 0
+
+        e4 = MidiEvent.from_dict({**base, "priority": None})
+        assert e4._priority is None


### PR DESCRIPTION
# feat/event_priority

## Summary

Add an optional **priority** field to events that allows higher-priority events to preempt a locked handler during its minimum duration window. Also includes handler queue improvements and new tests.

---

## Event Priority

### Model (`MidiEvent`)
- New internal field `_priority: int | None` with a `priority` property that always returns `int` (defaults to `0` when unset).
- **YAML round-trip**: `priority` is only written to the mapping file when explicitly set by the user (including explicit `0`). Omitted priority is never serialized.
- `from_dict` / `to_dict` handle all cases: missing key, explicit value, and explicit `null`.

### Handler (`MidiEventHandler`)
- Extracted `_should_discard_next_event()` to centralize the queue accept/reject logic:
  - **`None` in queue** (manual stop): never discarded — stop signal always reaches the main loop.
  - **Idle handler** (no current event): always accepts the next event.
  - **Duplicate event** (same event re-triggered): discarded.
  - **Locked + lower or equal priority**: discarded.
  - **Locked + strictly higher priority**: accepted, lock cleared (preemption).
- Discard reasons are logged with context (`CURRENT == NEXT` or `Locked and low priority`).
- Cleaned up comments on `_min_duration_task` cancellation and removed unused `TASK_YIELD_DELAY` constant.

### Editor UI
- **Event form**: optional numeric input with clear button, placeholder "0 when not set", and hint text explaining preemption.
- **Event card**: priority badge in the details row, muted when unset (effective 0), normal styling when explicitly authored.
- Empty field submits as `None` (omitted from YAML); any integer value is preserved.

---

## Tests

### `test_handlers.py` (new)
Unit tests for `_should_discard_next_event` covering all branches:
- Never discard `None` (stop signal)
- Never discard when idle
- Discard duplicate event
- No discard when unlocked
- Discard when locked with equal/lower priority
- Preempt when locked with strictly higher priority
- Effective priority 0 when both unset
- Log message assertions for both discard reasons

### `test_models.py` (extended)
- Minimal event asserts `_priority is None`, `priority == 0`, key absent from `to_dict()`
- Explicit `_priority=0` round-trips in `to_dict()`
- Property getter/setter behavior
- `from_dict` with omitted key, explicit value, explicit `0`, and explicit `null`
